### PR TITLE
fix remainder and quotient for edge case of 256

### DIFF
--- a/lib/base45-js.js
+++ b/lib/base45-js.js
@@ -24,7 +24,7 @@
   var divmod = function divmod(a,b) {
     var remainder = a
     var quotient = 0
-    if (a > b) {
+    if (a >= b) {
         remainder = a % b
 	quotient = (a - remainder) / b
     }


### PR DESCRIPTION
The divmod function behaves incorrectly if it is called with both parameters of value 256, the expected results should be [1, 0] while [0, 256] are returned.

This small difference makes [base45](https://www.npmjs.com/package/base45) (or Python [base45](https://github.com/kirei/python-base45)) return a different byte array in some cases.